### PR TITLE
Move checks for CSV readiness

### DIFF
--- a/ansible/roles/elasticsearch_operator/tasks/main.yml
+++ b/ansible/roles/elasticsearch_operator/tasks/main.yml
@@ -16,14 +16,19 @@
     shell: |-
       oc get packagemanifests {{ elasticsearch_operator_package_name }} -o jsonpath='{.status.channels[?(@.name == "{{ es_defaultchannel.stdout }}")].currentCSV}'
     register: es_currentCSV
+  
+  - name: set ES startingCSV
+    set_fact:
+      elasticsearch_operator_startingcsv: "{{ es_currentCSV.stdout }}"
+
+  - name: set ES operator channel
+    set_fact:
+      elasticsearch_operator_channel: "{{ es_defaultchannel.stdout }}"
 
   - name: "copy {{ resources_base_dir }}/elasticsearch/subscription.yml"
     template:
       src: "{{ resources_base_dir }}/elasticsearch/subscription.yml"
       dest: "{{ work_dir }}/elasticsearch-subscription.yml"
-    vars:
-      elasticsearch_operator_channel: "{{ es_defaultchannel.stdout }}"
-      elasticsearch_operator_startingcsv: "{{ es_currentCSV.stdout }}"  
 
   - name: "Create operatorgroups in {{ ocp_project }}"
     k8s:

--- a/ansible/roles/elasticsearch_operator/tasks/main.yml
+++ b/ansible/roles/elasticsearch_operator/tasks/main.yml
@@ -5,26 +5,25 @@
   register: resource_status
   ignore_errors: true
 
+- name: get default channel for elasticsearch operator
+  shell: |-
+    oc get packagemanifests {{ elasticsearch_operator_package_name }} -o jsonpath='{.status.defaultChannel}'
+  register: es_defaultchannel
+
+- name: get currentCSV for default channel
+  shell: |-
+    oc get packagemanifests {{ elasticsearch_operator_package_name }} -o jsonpath='{.status.channels[?(@.name == "{{ es_defaultchannel.stdout }}")].currentCSV}'
+  register: es_currentCSV
+
+- name: set ES startingCSV
+  set_fact:
+    elasticsearch_operator_startingcsv: "{{ es_currentCSV.stdout }}"
+
+- name: set ES operator channel
+  set_fact:
+    elasticsearch_operator_channel: "{{ es_defaultchannel.stdout }}"
+
 - block:
-
-  - name: get default channel for elasticsearch operator
-    shell: |-
-      oc get packagemanifests {{ elasticsearch_operator_package_name }} -o jsonpath='{.status.defaultChannel}'
-    register: es_defaultchannel
-
-  - name: get currentCSV for default channel
-    shell: |-
-      oc get packagemanifests {{ elasticsearch_operator_package_name }} -o jsonpath='{.status.channels[?(@.name == "{{ es_defaultchannel.stdout }}")].currentCSV}'
-    register: es_currentCSV
-  
-  - name: set ES startingCSV
-    set_fact:
-      elasticsearch_operator_startingcsv: "{{ es_currentCSV.stdout }}"
-
-  - name: set ES operator channel
-    set_fact:
-      elasticsearch_operator_channel: "{{ es_defaultchannel.stdout }}"
-
   - name: "copy {{ resources_base_dir }}/elasticsearch/subscription.yml"
     template:
       src: "{{ resources_base_dir }}/elasticsearch/subscription.yml"

--- a/ansible/roles/jaeger_operator/tasks/main.yml
+++ b/ansible/roles/jaeger_operator/tasks/main.yml
@@ -17,13 +17,18 @@
       oc get packagemanifests {{ jaeger_operator_package_name }} -o jsonpath='{.status.channels[?(@.name == "{{ jaeger_defaultchannel.stdout }}")].currentCSV}'
     register: jaeger_currentCSV
 
+  - name: set Jaeger startingCSV
+    set_fact:
+      jaeger_operator_startingcsv: "{{ jaeger_currentCSV.stdout }}" 
+
+  - name: set Jaeger operator channel
+    set_fact:
+      jaeger_operator_channel: "{{ jaeger_defaultchannel.stdout }}"
+
   - name: "copy {{ resources_base_dir }}/jaeger/subscription.yml"
     template:
       src: "{{ resources_base_dir }}/jaeger/subscription.yml"
       dest: "{{ work_dir }}/jaeger-subscription.yml"
-    vars:
-      jaeger_operator_channel: "{{ jaeger_defaultchannel.stdout }}"
-      jaeger_operator_startingcsv: "{{ jaeger_currentCSV.stdout }}" 
 
   - name: "Create operatorgroups in {{ ocp_project }}"
     k8s:

--- a/ansible/roles/jaeger_operator/tasks/main.yml
+++ b/ansible/roles/jaeger_operator/tasks/main.yml
@@ -5,26 +5,25 @@
   register: resource_status
   ignore_errors: true
 
+- name: get default channel for jaeger operator
+  shell: |-
+    oc get packagemanifests {{ jaeger_operator_package_name }} -o jsonpath='{.status.defaultChannel}'
+  register: jaeger_defaultchannel
+
+- name: get currentCSV for default channel
+  shell: |-
+    oc get packagemanifests {{ jaeger_operator_package_name }} -o jsonpath='{.status.channels[?(@.name == "{{ jaeger_defaultchannel.stdout }}")].currentCSV}'
+  register: jaeger_currentCSV
+
+- name: set Jaeger startingCSV
+  set_fact:
+    jaeger_operator_startingcsv: "{{ jaeger_currentCSV.stdout }}" 
+
+- name: set Jaeger operator channel
+  set_fact:
+    jaeger_operator_channel: "{{ jaeger_defaultchannel.stdout }}"
+
 - block:
-
-  - name: get default channel for jaeger operator
-    shell: |-
-      oc get packagemanifests {{ jaeger_operator_package_name }} -o jsonpath='{.status.defaultChannel}'
-    register: jaeger_defaultchannel
-
-  - name: get currentCSV for default channel
-    shell: |-
-      oc get packagemanifests {{ jaeger_operator_package_name }} -o jsonpath='{.status.channels[?(@.name == "{{ jaeger_defaultchannel.stdout }}")].currentCSV}'
-    register: jaeger_currentCSV
-
-  - name: set Jaeger startingCSV
-    set_fact:
-      jaeger_operator_startingcsv: "{{ jaeger_currentCSV.stdout }}" 
-
-  - name: set Jaeger operator channel
-    set_fact:
-      jaeger_operator_channel: "{{ jaeger_defaultchannel.stdout }}"
-
   - name: "copy {{ resources_base_dir }}/jaeger/subscription.yml"
     template:
       src: "{{ resources_base_dir }}/jaeger/subscription.yml"

--- a/ansible/roles/kiali_operator/tasks/main.yml
+++ b/ansible/roles/kiali_operator/tasks/main.yml
@@ -5,26 +5,25 @@
   register: resource_status
   ignore_errors: true
 
+- name: get default channel for kiali operator
+  shell: |-
+    oc get packagemanifests {{ kiali_operator_package_name }} -o jsonpath='{.status.defaultChannel}'
+  register: kiali_defaultchannel
+
+- name: get currentCSV for default channel
+  shell: |-
+    oc get packagemanifests {{ kiali_operator_package_name }} -o jsonpath='{.status.channels[?(@.name == "{{ kiali_defaultchannel.stdout }}")].currentCSV}'
+  register: kiali_currentCSV
+
+- name: set Kiali startingCSV
+  set_fact:
+    kiali_operator_startingcsv: "{{ kiali_currentCSV.stdout }}" 
+
+- name: set Kiali operator channel
+  set_fact:
+    kiali_operator_channel: "{{ kiali_defaultchannel.stdout }}"
+
 - block:
-
-  - name: get default channel for kiali operator
-    shell: |-
-      oc get packagemanifests {{ kiali_operator_package_name }} -o jsonpath='{.status.defaultChannel}'
-    register: kiali_defaultchannel
-
-  - name: get currentCSV for default channel
-    shell: |-
-      oc get packagemanifests {{ kiali_operator_package_name }} -o jsonpath='{.status.channels[?(@.name == "{{ kiali_defaultchannel.stdout }}")].currentCSV}'
-    register: kiali_currentCSV
-  
-  - name: set Kiali startingCSV
-    set_fact:
-      kiali_operator_startingcsv: "{{ kiali_currentCSV.stdout }}" 
-
-  - name: set Kiali operator channel
-    set_fact:
-      kiali_operator_channel: "{{ kiali_defaultchannel.stdout }}"
-
   - name: "copy {{ resources_base_dir }}/kiali/subscription.yml"
     template:
       src: "{{ resources_base_dir }}/kiali/subscription.yml"

--- a/ansible/roles/kiali_operator/tasks/main.yml
+++ b/ansible/roles/kiali_operator/tasks/main.yml
@@ -16,14 +16,19 @@
     shell: |-
       oc get packagemanifests {{ kiali_operator_package_name }} -o jsonpath='{.status.channels[?(@.name == "{{ kiali_defaultchannel.stdout }}")].currentCSV}'
     register: kiali_currentCSV
+  
+  - name: set Kiali startingCSV
+    set_fact:
+      kiali_operator_startingcsv: "{{ kiali_currentCSV.stdout }}" 
+
+  - name: set Kiali operator channel
+    set_fact:
+      kiali_operator_channel: "{{ kiali_defaultchannel.stdout }}"
 
   - name: "copy {{ resources_base_dir }}/kiali/subscription.yml"
     template:
       src: "{{ resources_base_dir }}/kiali/subscription.yml"
       dest: "{{ work_dir }}/kiali-subscription.yml"
-    vars:
-      kiali_operator_channel: "{{ kiali_defaultchannel.stdout }}"
-      kiali_operator_startingcsv: "{{ kiali_currentCSV.stdout }}" 
 
   - name: "Create operatorgroups in {{ ocp_project }}"
     k8s:

--- a/ansible/roles/maistra_control_plane/tasks/main.yml
+++ b/ansible/roles/maistra_control_plane/tasks/main.yml
@@ -1,4 +1,63 @@
 ---
+- name: Wait for ES operator to be available in project
+  k8s_info:
+    api_version: operators.coreos.com/v1alpha1
+    kind: ClusterServiceVersion
+    name: "{{ elasticsearch_operator_startingcsv }}"
+    namespace: "{{ ocp_project }}"
+  register: es_csv_check
+  retries: 30
+  delay: 20
+  until:
+  - es_csv_check.resources | length > 0
+  - es_csv_check.resources[0].status is defined
+  - es_csv_check.resources[0].status.phase is defined
+  - es_csv_check.resources[0].status.phase == "Succeeded"
+
+- name: Wait for Jaeger operator to be available in project
+  k8s_info:
+    api_version: operators.coreos.com/v1alpha1
+    kind: ClusterServiceVersion
+    name: "{{ jaeger_operator_startingcsv }}"
+    namespace: "{{ ocp_project }}"
+  register: jaeger_csv_check
+  retries: 30
+  delay: 20
+  until:
+  - jaeger_csv_check.resources | length > 0
+  - jaeger_csv_check.resources[0].status is defined
+  - jaeger_csv_check.resources[0].status.phase is defined
+  - jaeger_csv_check.resources[0].status.phase == "Succeeded"
+
+- name: Wait for Kiali operator to be available in project
+  k8s_info:
+    api_version: operators.coreos.com/v1alpha1
+    kind: ClusterServiceVersion
+    name: "{{ kiali_operator_startingcsv }}"
+    namespace: "{{ ocp_project }}"
+  register: kiali_csv_check
+  retries: 30
+  delay: 20
+  until:
+  - kiali_csv_check.resources | length > 0
+  - kiali_csv_check.resources[0].status is defined
+  - kiali_csv_check.resources[0].status.phase is defined
+  - kiali_csv_check.resources[0].status.phase == "Succeeded"
+
+- name: Wait for Maistra operator to be available in project
+  k8s_info:
+    api_version: operators.coreos.com/v1alpha1
+    kind: ClusterServiceVersion
+    name: "{{ maistra_operator_startingcsv }}"
+    namespace: "{{ ocp_project }}"
+  register: maistra_csv_check
+  retries: 30
+  delay: 20
+  until:
+  - maistra_csv_check.resources | length > 0
+  - maistra_csv_check.resources[0].status is defined
+  - maistra_csv_check.resources[0].status.phase is defined
+  - maistra_csv_check.resources[0].status.phase == "Succeeded"
 
 - name: "Install maistra control_plane in {{ ocp_project }}"
   shell: |

--- a/ansible/roles/maistra_operator/tasks/main.yml
+++ b/ansible/roles/maistra_operator/tasks/main.yml
@@ -5,26 +5,25 @@
   register: resource_status
   ignore_errors: true
 
+- name: get default channel for maistra operator
+  shell: |-
+    oc get packagemanifests {{ maistra_operator_package_name }} -o jsonpath='{.status.defaultChannel}'
+  register: maistra_defaultchannel
+
+- name: get currentCSV for default channel
+  shell: |-
+    oc get packagemanifests {{ maistra_operator_package_name }} -o jsonpath='{.status.channels[?(@.name == "{{ maistra_defaultchannel.stdout }}")].currentCSV}'
+  register: maistra_currentCSV
+
+- name: set Maistra startingCSV
+  set_fact:
+    maistra_operator_startingcsv: "{{ maistra_currentCSV.stdout }}" 
+
+- name: set Maistra operator channel
+  set_fact:
+    maistra_operator_channel: "{{ maistra_defaultchannel.stdout }}"
+
 - block:
-
-  - name: get default channel for maistra operator
-    shell: |-
-      oc get packagemanifests {{ maistra_operator_package_name }} -o jsonpath='{.status.defaultChannel}'
-    register: maistra_defaultchannel
-
-  - name: get currentCSV for default channel
-    shell: |-
-      oc get packagemanifests {{ maistra_operator_package_name }} -o jsonpath='{.status.channels[?(@.name == "{{ maistra_defaultchannel.stdout }}")].currentCSV}'
-    register: maistra_currentCSV
-
-  - name: set Maistra startingCSV
-    set_fact:
-      maistra_operator_startingcsv: "{{ maistra_currentCSV.stdout }}" 
-
-  - name: set Maistra operator channel
-    set_fact:
-      maistra_operator_channel: "{{ maistra_defaultchannel.stdout }}"
-
   - name: "copy {{ resources_base_dir }}/maistra/subscription.yml"
     template:
       src: "{{ resources_base_dir }}/maistra/subscription.yml"

--- a/ansible/roles/maistra_operator/tasks/main.yml
+++ b/ansible/roles/maistra_operator/tasks/main.yml
@@ -17,13 +17,18 @@
       oc get packagemanifests {{ maistra_operator_package_name }} -o jsonpath='{.status.channels[?(@.name == "{{ maistra_defaultchannel.stdout }}")].currentCSV}'
     register: maistra_currentCSV
 
+  - name: set Maistra startingCSV
+    set_fact:
+      maistra_operator_startingcsv: "{{ maistra_currentCSV.stdout }}" 
+
+  - name: set Maistra operator channel
+    set_fact:
+      maistra_operator_channel: "{{ maistra_defaultchannel.stdout }}"
+
   - name: "copy {{ resources_base_dir }}/maistra/subscription.yml"
     template:
       src: "{{ resources_base_dir }}/maistra/subscription.yml"
       dest: "{{ work_dir }}/maistra-subscription.yml"
-    vars:
-      maistra_operator_channel: "{{ maistra_defaultchannel.stdout }}"
-      maistra_operator_startingcsv: "{{ maistra_currentCSV.stdout }}" 
 
   - name: "Create operatorgroups in {{ ocp_project }}"
     k8s:


### PR DESCRIPTION
SMCP can't be created until all of the CSVs are Succeeded in a project as they are copied in.